### PR TITLE
Overhaul signal handlers.

### DIFF
--- a/client/fuseful.hpp
+++ b/client/fuseful.hpp
@@ -103,20 +103,17 @@ void lowlevel_notify_inval_inode_detached(fuse_ino_t ino, off_t off, off_t len);
 // They're not fatal, but they might be leaking file descriptors.
 void my_close_failure_handler(const std::string& msg);
 
-// handle_signals - one-stop-shopping
-void handle_signals();
-
 // fuse_main_ll - lifted from examples/hello_ll.c in the fuse 2.9.2 tree.
-int fuse_main_ll(fuse_args* args, const fuse_lowlevel_ops& llops,
-                 bool single_threaded_only);
+int fuseful_main_ll(fuse_args* args, const fuse_lowlevel_ops& llops,
+                 bool single_threaded_only, void (*crash_handler)());
 
-// fuse_teardown - gracefully bring down the lowlevel fuse
+// fuseful_teardown - gracefully bring down the lowlevel fuse
 // infrastructure: sessions are destroyed, channels are closed,
 // signals are restored, mounts are unmounted.  May be called when
 // things are crashing or failing or the system is critically short of
 // resources like memory or threads, in which case a best-effort is
 // made to clean up as much as possible.
-void fuse_teardown();
+void fuseful_teardown();
 
 // fuseful_report - report statistics.
 std::string fuseful_report();
@@ -134,5 +131,6 @@ extern std::string fuse_device_option;
 extern std::string g_mountpoint;
 extern fuse_ino_t g_mount_dotdot_ino;
 extern fuse_session* g_session;
+extern std::string g_named_pipe_name;
 void fuse_options_to_envvars(fuse_args* args, const std::string& desc, std::initializer_list<std::string> envvars);
 

--- a/core123/include/core123/complaints.hpp
+++ b/core123/include/core123/complaints.hpp
@@ -212,6 +212,19 @@ inline void log_notice(const std::string& msg){
     complain(LOG_NOTICE, msg);
 }
 
+// _complain_direct - send a complaint directly to the channel without
+// any manipulation or modification.  No locks are held.  No counters
+// are incremented.  No datestamps are prepended.  No rate-limiting is
+// applied, etc.  On the other hand, _complain_direct may be safe to
+// call from a signal handler.  It is async-signal-safe if the current
+// destination is a file or %stdout or %stderr.  If the destination is
+// %syslog, then it will ultimately call syslog, which isn't
+// async-signal-safe, but otherwise, it avoids async-signal-unsafe
+// operations.  N.B.  In the future, this might be fully
+// async-signal-safe.  See the comments about log_channel::_send in
+// log_channel.hpp.
+void _complain_direct(int lev, str_view sv);
+
 // Now for the overloads that that take a printf-style format string
 // and a ... arglist.  They can be disabled with a #define.
 #if !defined(NO_CORE123_FORMATTED_COMPLAINTS)

--- a/core123/lib/complaints.cpp
+++ b/core123/lib/complaints.cpp
@@ -219,4 +219,8 @@ _whatnest (int priority, const std::string& pfx, char const* const* beg, char co
     return ret;
 }
 
+void _complain_direct(int lev, str_view sv){
+    the_channel()._send(lev, sv);
+}
+
 }

--- a/core123/lib/log_channel.cpp
+++ b/core123/lib/log_channel.cpp
@@ -66,9 +66,13 @@ void log_channel::send(int level, str_view sv) const {
     // Should we throw on error?
     // level is only used with syslog.  Oversight?  Inadequate  API?
     // Lack of imagination?
+    std::lock_guard<std::mutex> lg(mtx);
+    _send(level, sv);
+}
+
+void log_channel::_send(int level, str_view sv) const {
     if(sv.size() == 0)
         return;
-    std::lock_guard<std::mutex> lg(mtx);
     if(dest_syslog){
         // if level is unspecified (-1) use dest_lev.  If it
         // is specified, silently mask off any non-level bits.


### PR DESCRIPTION
New features:

- the signal handler sends a log message with the signal number to the
  standard "log_destination".
- it's *almost* async-thread-safe (except for the call to syslog that
  does the above).
- all signals are caught.  All non-fatal signals (except for SIGPIPE,
  SIGALRM and SIGCHLD) result in graceful termination.
- fatal signals (SEGV, BUS, ABRT, etc) call fuse_unmount before
  re-raising themselves with SIG_DFL.  fuse_unmount is definitely not
  async-thread-safe, but the risk seems worth it when the alternative is
  surely to leave the mount-point in a 'Transport endpoint is not
  connected' state.
- Add an extra 'crash_handler' callback argument to fuse_main_ll.
- Name changes:
    fuse_main_ll -> fuseful_main_ll
    fuse_teardown -> fuseful_teardown
  to emphasize that these are "ours" and not "theirs".
- new methods in complaints.hpp and log_channel.hpp that offer an
  (almost) async-signal-safe way to complain.