### PR TITLE
Add encrypted releases OAuth token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,16 @@ sudo: required
 services:
     - docker
 
+deploy:
+    provider: releases
+    api_key:
+        secure: "UYxJTTcSmL6LcEpmW4YjR91MUsQeprHcLbe10C4ps/nSmlKEHvjE+IObJbl1SVPs2/zFYlOhlSIegpAxedgU+dh49zmgiVj4ArgHRX4bKh7U7MVPsEnGuIlsEipfjpBsddmui1xSY8FM2anQ5fEWYSFOOL1DSmZ/5LJd+cJnBjnyAnU1MkS2xbLIJju4fVSmwiZ5Y9XrFZ0OqFNDxL3NWWMTQLOjnxwuK1kda6rAhami3B/94+mbQPx+7tzQTSifLswZgm4lTCEbpezr5YWj+WZ2AQ/Gs5CTEmLbH4J7uEBYj1BDcqVQxp8R8IfU/iZuyOvbv1HbO50S0foq6T7EbJOHUUaMN2i/uB9QEM2IJfmiBoTySiDY4ubvG0BzY5Hi5Nz122d+TPele9wv3/Fio6SykLboNl0/r9Ik7TniVLLMnilUMvxMLvEuhAVm68lnOg5aO9u8I5YLiBURo1bOJ2GJTDPdfsZ2ffrEQzV+1OYjK2dgbJPVPJIMe2y4+QTatQ/eUFOYYh/TA7doKPNFHEZA/3P9uW1HXnXReXQE0vktiMJ6J0KLKXMouCXoK47hd6mhKYVuGsQELh8XblkX5jsJGV+u2jFEtvAIBUk0Ts2t6cGgZh7Ku9Lz0wMUER1xLiUFyQ6HisFYfxs1Odb07p7ZbwWcGDmpwxrfLyTAJfk="
+    file: "placeholder"
+    skip_cleanup: true
+    draft: true
+    on:
+        tags: true
+
 env:
     - DOCKER_IMAGE=alpine:3.9
     - DOCKER_IMAGE=centos:7


### PR DESCRIPTION
Note that the OAuth token as the public_repo scope on github and was
encrypted using the Travis project's public key via the following
command :

travis encrypt -r DEShawResearch/fs123 api_key=XXX

The travis CLI was installed in an ubuntu:18.04 container:

apt update
apt install ruby ruby-dev build-essential
gem install travis

Ref:
https://docs.travis-ci.com/user/deployment/releases/#using-travis-ci-client-to-populate-initial-deployment-configuration
Ref: https://docs.travis-ci.com/user/encryption-keys/