### PR TITLE
Don't cast away constness of string::data()

### DIFF
--- a/core123/include/core123/threeroe.hpp
+++ b/core123/include/core123/threeroe.hpp
@@ -326,7 +326,7 @@ public:
     // std::string, std::array.
     template<typename V>
     threeroe& update(const V& v){
-        return update((void*)v.data(), v.size()*sizeof(*v.data()));
+        return update(reinterpret_cast<const void*>(v.data()), v.size()*sizeof(*v.data()));
     }    
 
     // Output functions and types

--- a/include/fs123/fs123server.hpp
+++ b/include/fs123/fs123server.hpp
@@ -381,7 +381,7 @@ private:
     }
     void copy_to_pbuf(core123::str_view s){
         allocate_pbuf(s.size());
-        buf = buf.append(core123::as_uchar_span(s));
+        buf = buf.append(s);
     }
     // The reply methods are private.  There are friend versions that take
     // a up 'this' argument that are public.

--- a/lib/fs123server.cpp
+++ b/lib/fs123server.cpp
@@ -1028,7 +1028,7 @@ bool req::add_dirent(core123::str_view name, long offset, int type, uint64_t est
     size_t osslen = core123::ostream_size(oss);
     if(osslen >= buf.avail_back())  // >=, not > so there's room for the final newline
         return false;
-    buf = buf.append(core123::as_uchar_span(oss.str()));
+    buf = buf.append(oss.str());
     dir_lastoff = offset;
     return true;
 }
@@ -1064,7 +1064,7 @@ void req::d_reply(bool at_eof, uint64_t etag64, uint64_t esc, const std::string&
         }else{
             final_telldir = dir_lastoff;
         }
-        buf = buf.append(as_uchar_span("\n"));            // N.B.  we left room for this in dirbuf.add()
+        buf = buf.append("\n");            // N.B.  we left room for this in dirbuf.add()
         add_hdr(ohdrs, HHNO, std::to_string(final_telldir) + (at_eof?" EOF":""));
         common_reply200(cc, etag64);
  }catch(std::exception& e) { exception_reply(e); }
@@ -1081,7 +1081,7 @@ void req::f_reply(size_t nread, uint64_t content_validator, uint64_t etag64, uin
         DIAGf(_fs123server, "prepend content validator (%llu) to buf.  buf.avail_front() = %zd, buf.avail_back()=%zd",
               (unsigned long long)content_validator, buf.avail_front(), buf.avail_back());
         if(proto_minor >= 2) // always?
-            buf = buf.prepend(as_uchar_span(core123::netstring(std::to_string(content_validator))));
+            buf = buf.prepend(core123::netstring(std::to_string(content_validator)));
 
         add_hdr(ohdrs, HHCOOKIE, std::to_string(esc));
         common_reply200(cc, etag64);

--- a/lib/ut_content_codec.cpp
+++ b/lib/ut_content_codec.cpp
@@ -55,7 +55,7 @@ void try_to_use_sfname(){
     
 void replace_content(padded_uchar_span& ss, size_t leader, const std::string& s){
     ss = ss.bounding_box().subspan(leader, 0);
-    ss = ss.append(as_uchar_span(s));
+    ss = ss.append(s);
 }
 
 struct upspan : public core123::padded_uchar_span{


### PR DESCRIPTION
This should make things even safer to run when std::string is
copy-on-write (which it shouldn't be, but sometimes is).