### PR TITLE
"parallelize" make -j check in core123

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,21 +39,15 @@ script:
         --mount=type=bind,src=$(pwd -P),destination=/fs123
         --device /dev/fuse --cap-add SYS_PTRACE --cap-add SYS_ADMIN --security-opt apparmor:unconfined
         ${DOCKER_IMAGE}
-        /bin/sh -e -c "cd /fs123 && . ./misc/prereqs.${DOCKER_IMAGE} && make && make check && make install"
+        /bin/sh -e -c "cd /fs123 && . ./misc/prereqs.${DOCKER_IMAGE} && make -j4 && make -j4 check && make -j4 core123-check && make install"
 
 # There must be a better way ...
 after_failure:
-    - echo CAT S/FS123.DIAG
     - cat s/fs123.diag
-    - echo CAT S/ERRORLOG
     - cat s/errorlog.1 s/errorlog
-    - echo CAT S/EXPORTD.STAR
     - cat s/exportd.*
-    - echo CAT C/FS123.DIAG
     - cat c/fs123.diag
-    - echo CAT C/FS123.ERR
     - cat c/fs123.err
-    - echo CAT C/FS123.EXSTATUS
     - cat c/fs123.exstatus
 
 # vim: ts=4:sw=4:et:ai

--- a/core123/GNUmakefile
+++ b/core123/GNUmakefile
@@ -6,11 +6,10 @@
 #
 #  cd /path/to/build-dir
 #  make -C /path/to/checked-out-core123
-
-# Everything in this file is fairly generic, it is invoked by various dmk-* scripts
-# after they set up the environment appropriately.
-# If you have all the needed dependencies and the right compiler as CC, CXX,
-# this may just work using make
+#
+# Everything in this file is fairly generic.  If necessary, use an
+# external script to install dependencies and/or set variables like
+# CC, CXX, CPPFLAGS, LDLIBS, etc.
 
 mkfile_path := $(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
 top/ := $(dir $(mkfile_path))
@@ -21,13 +20,33 @@ OPT?=-O3 # if not explicitly set
 PREFIX?=/usr/local
 
 CPPFLAGS+=-I$(top/)include
-CXXFLAGS+=-Wno-deprecated-declarations
 CXXFLAGS+=$(OPT)
-CXXFLAGS+=-Wall
+# N.B.  we use the '#pragma GCC diagnostic ignore  ...' to selectively turn
+# off a few warnings.  One of them is -Wint-in-bool-context, which is
+# so new that that older compilers complain when we try to ignore it.
+# So we addd -Wno-pragmas to keep the older compiler from complaining.
+CXXFLAGS+=-Wall -Werror -Wno-pragmas
 CXXFLAGS+=-std=c++17
+CXXFLAGS+=-ggdb
+LDFLAGS+=-L.
+TARGET_ARCH+=-pthread
+
+# Note - warning options are completely non-standard.  It's a mess!
+#
+# To compile the unit tests with icc, use something like:
+# CXXFLAGS+=" -wd61"   # integer operation result is out of range (ut_svto.cpp:127, 129, 131)
+# CXXFLAGS+=" -wd10006" # -Wno-pragmas in the GNUmakefile.  Ugh.
+#
+# To compile the unit tests with clang, use something like:
+# CXXFLAGS+="-Wno-unknown-warning-option " # -Wno-pragmas in the GNUmakefile
+#
+
 ifndef NOLIBRT
 LDLIBS+=-lrt # needed to link core123 with glibc<2.17, not harmful otherwise
 endif
+
+.PHONY: all
+all: check
 
 LINK.o = $(CXX) $(LDFLAGS) $(TARGET_ARCH)
 
@@ -93,17 +112,18 @@ unit_tests:=\
 
 shunit_tests:=ut_configparser
 
-# ut_configparser is a shell script.  It needs test_configparser to run, but
-# it is not compiled, so use the | construct.
-ut_configparser : | testconfigparser
+unit_tests.out:=$(addsuffix .out, $(unit_tests) $(shunit_tests))
+ut_%.out : ut_%
+	./$< > $@.tmp && mv $@.tmp $@
 
-exe:=$(unit_tests) $(shunit_tests)
+ut_diagtime_flood.out: ut_diagtime_flood
+	DIAG_OPTS=flood ./$< > $@.tmp && mv $@.tmp $@
 
-all: $(exe)
-.PHONY: all
+ut_configparser.out: ut_configparser testconfigparser
+	TESTDATA=$(top/)/ut/testdata ./$< > $@.tmp && mv $@.tmp $@
 
 .PHONY: check
-check: runtests
+check: $(unit_tests.out)
 
 .PHONY: install
 install:
@@ -111,19 +131,11 @@ install:
 	mkdir -p $(PREFIX)/include/core123 $(PREFIX)/lib
 	cp -a $(top/)include/core123/* $(PREFIX)/include/core123
 
-# XXX should we build unit tests with static too? instead?
-
-# Unit tests are in ut
-$(exe): LDFLAGS+=-L.
-$(exe): LDFLAGS+=-pthread
-$(addsuffix .o, $(exe)): CXXFLAGS+=-ggdb
+# Special cases for specific unit tests:
 
 ut_expiring.o : CPPFLAGS += $(VALGRIND_CPPFLAGS)
 
-ut_svto.o ut_scanint.o: CPPFLAGS+=-Wno-int-in-bool-context
-
-ut_configparser: ut_configparser.sh
-	cp -av $< $@
+ut_scanint.o: CXXFLAGS+=-Wno-int-in-bool-context  # Why?  There's a pragma in the code.
 
 ut_diagtime_flood: ut_diagtime_flood.o
 ut_diagtime_flood.o: ut_diagtime.cpp
@@ -134,20 +146,23 @@ ut_diagstatic_initializers : ut_diagstatic_initializersB.o
 ut_stats.o ut_stats2.o : CPPFLAGS+=-I$(top/)ut
 ut_stats : ut_stats2.o
 
-#ut_stacktrace.o : CPPFLAGS += -DBACKWARD_HAS_BFD=1
-#ut_stacktrace : LDLIBS += -lbfd -ldl
+# We default to BACKWARD_HAS_DW.  To use something different,
+# put a -DBACKWARD_HAS_SOMETHING=1 in CPPFLAGS and whatever
+# else is needed in LDLIBS.  See ../misc/prereqs.alpine:* for
+# possibilities.
+ifeq (,$(findstring BACKWARD_HAS,$(CPPFLAGS)))
 ut_stacktrace.o : CPPFLAGS += -DBACKWARD_HAS_DW=1
 ut_stacktrace : LDLIBS += -ldw
+endif
 
 ut_streamutils : LDFLAGS += -pthread
 
-.PHONY: runtests
-runtests: $(exe) $(shunit_tests)
-	for t in $(unit_tests) $(shunit_tests); do echo Running $$t; DIAG_OPTS=flood TESTDATA=$(top/)ut/testdata ./$$t || exit 1; echo Finished $$t; done
+ut_configparser: ut_configparser.sh
+	cp -av $< $@
 
 .PHONY: clean
 clean:
-	rm -f $(exe) *.o *.d *.a *.so *.core
+	rm -f $(unit_tests) $(shunit_tests) *.o *.d *.a *.so *.core ut_*.out ut_*.out.tmp testconfigparser
 
 # the paulandlesley.com autodepends hack, lifted from makefragments,
 # but don't do a recursive descent into all subdirs (which would be

--- a/core123/include/core123/bloomfilter.hpp
+++ b/core123/include/core123/bloomfilter.hpp
@@ -117,7 +117,7 @@ public:
     size_t numhashes() const { return nhashes_; }
     size_t numentries() const { return nentries_; }
     // probability of false positive
-    const double falseprob() const {
+    double falseprob() const {
         return bloom_estimate_falseprob(bits_.sizebits(), nhashes_, nentries_);
     }
     friend std::ostream& operator<<(std::ostream& out, const bloomfilter& b) {

--- a/core123/include/core123/simd_threefry.hpp
+++ b/core123/include/core123/simd_threefry.hpp
@@ -75,22 +75,21 @@
 //
 //    warning: AVX512F vector return without AVX512F enabled changes the ABI [-Wpsabi]
 //
-// It's possible to silence these warnings with:
-//  #pragma GCC diagnostic push
-//  #pragma GCC diagnostic ignored "-Wpsabi"
-//  #include <core123/simd_threefry.hpp>
-//  #pragma GCC diagnostic pop
+// It's possible to silence these warnings by uncommenting the #pragmas below.
 //
 // Since this is header-only code, it tempting to think that ABI
 // issues don't matter - the caller is unavoidably compiled with the
 // same ABI as the callee because they're in the same translation
 // unit.  But I know enough to know I don't know for sure.
+// See:  https://stackoverflow.com/a/52391447/989586
 
 #pragma once
 #ifndef __GNUC__
 #error "This header relies on GNUC Vector Extensions.  It is unusable/meaningless without them"
 #endif
 
+//#pragma GCC diagnostic push
+//#pragma GCC diagnostic ignored "-Wpsabi"
 #include "threefry.hpp"
 
 using uint64_tx8 = uint64_t __attribute__ ((__vector_size__ (64))); // aka __v8du in <immintrin.h>
@@ -131,6 +130,7 @@ inline
 uint32_tx2 rotl<uint32_tx2>(uint32_tx2 x, unsigned s){
     return (x<<s) | (x>>(32u-s));
 }
+//#pragma GCC diagnostic pop
 
 // There's really a lot of repetition here... Fix it?
 template<>

--- a/core123/include/core123/threefry.hpp
+++ b/core123/include/core123/threefry.hpp
@@ -290,6 +290,10 @@ public:
         return is >> static_cast<common_type&>(f);
     }
 
+    // N.B.  when #include-ed in simd_threefry.hpp, gcc says this, even with warnings disabled:
+    // ../include/core123/threefry.hpp: In member function ‘core123::threefry<4, Uint, R, Constants>::_ctr_type core123::threefry<4, Uint, R, Constants>::operator()(core123::threefry<4, Uint, R, Constants>::_ctr_type) const [with Uint = __vector(8) long unsigned int; unsigned int R = 12; Constants = core123::threefry_constants<4, __vector(8) long unsigned int>]’:
+    // ../include/core123/threefry.hpp:293:15: note: the ABI for passing parameters with 64-byte alignment has changed in GCC 4.6
+    // AFAIK, this is a non-issue, but I don't know how to silence it.
     _ctr_type operator()(_ctr_type c) const { 
         Uint ks[5];
         Uint c0, c1, c2, c3;

--- a/core123/include/core123/uchar_span.hpp
+++ b/core123/include/core123/uchar_span.hpp
@@ -46,6 +46,7 @@
 #pragma once
 #include "span.hpp"
 #include "str_view.hpp"
+#include <string>
 #include <cstddef>
 #include <memory>
 #include <cstring>

--- a/core123/ut/ut_scanint.cpp
+++ b/core123/ut/ut_scanint.cpp
@@ -17,7 +17,7 @@ using core123::str_view;
 #pragma GCC diagnostic ignored "-Woverflow"
 #pragma GCC diagnostic ignored "-Wtype-limits"
 #pragma GCC diagnostic ignored "-Wbool-compare"
-//#pragma GCC diagnostic ignored "-Wint-in-bool-context"
+#pragma GCC diagnostic ignored "-Wint-in-bool-context"
 
 int FAIL = 0;
 #define Assert(P) do{ if(!(P)){ std::cerr << "Assertion failed: "  #P << std::endl; FAIL++; } } while(0)

--- a/core123/ut/ut_simd_threefry.cpp
+++ b/core123/ut/ut_simd_threefry.cpp
@@ -1,3 +1,11 @@
+#if defined(__ICC)
+#include <stdio.h>
+int main(int, char **){
+    printf(__FILE__ " Icc (through version 18) doesn't fully support gcc's 'vector' extensions.");
+    return 0;
+}
+#else
+#pragma GCC diagnostic ignored "-Wpsabi" // see comments in simd_threefry.hpp
 #include <core123/simd_threefry.hpp>
 #include <core123/streamutils.hpp>
 #include <core123/timeit.hpp>
@@ -85,3 +93,4 @@ int main(int argc, char **argv){
 
     return 0;
 }
+#endif // not __ICC

--- a/core123/ut/ut_svto.cpp
+++ b/core123/ut/ut_svto.cpp
@@ -17,7 +17,7 @@ using core123::str_view;
 // really there because scanx (should) throw before we try
 // to do comparisons with overflowing constant expresions.
 #pragma GCC diagnostic ignored "-Woverflow"
-//#pragma GCC diagnostic ignored "-Wint-in-bool-context"
+#pragma GCC diagnostic ignored "-Wint-in-bool-context"
 
 int FAIL = 0;
 #define Assert(P) do{ if(!(P)){ std::cerr << "Assertion failed on line " << __LINE__ << ": "  #P << std::endl; FAIL++; } } while(0)

--- a/misc/prereqs.alpine:3.11.5
+++ b/misc/prereqs.alpine:3.11.5
@@ -24,11 +24,11 @@ apk add --no-cache python3
 # backward.hpp to work.
 apk add --no-cache libdwarf libdwarf-dev libdwarf-static elfutils-dev
 export LDLIBS="-ldwarf -lelf"
-export CPPFLAGS="-DBACKWARD_HAS_DWARF -I/usr/include/libdwarf -I/usr/include/libelf"
+export CPPFLAGS="-DBACKWARD_HAS_DWARF=1 -I/usr/include/libdwarf"
 # This is sufficient to run make -f .../GNUmakefile check
 # valgrind will report a couple of false positives.
 #
-# To build staticly, we need to compile static versions of libfuse.
+# To build staticly, we need to compile a static versions of libfuse.
 wget https://github.com/libfuse/libfuse/releases/download/fuse-2.9.9/fuse-2.9.9.tar.gz -O- | tar xfz -
 cd fuse-2.9.9
 ./configure --enable-shared=no

--- a/misc/prereqs.centos:7
+++ b/misc/prereqs.centos:7
@@ -5,6 +5,7 @@ yum -y install centos-release-scl
 yum -y install devtoolset-8
 yum -y install fuse fuse-devel
 yum -y install libsodium-devel
+yum -y install elfutils-devel
 yum -y install curl-devel openssl-devel
 yum -y install libevent-devel
 yum -y install time attr e2fsprogs

--- a/misc/prereqs.fedora:32
+++ b/misc/prereqs.fedora:32
@@ -8,4 +8,4 @@ yum -y install zlib-devel
 yum -y install elfutils-devel
 yum -y install curl-devel openssl-devel
 yum -y install libevent-devel
-yum -y install time attr e2fsprogs
+yum -y install time attr e2fsprogs diffutils

--- a/misc/prereqs.ubuntu:bionic
+++ b/misc/prereqs.ubuntu:bionic
@@ -2,5 +2,5 @@
 set -x
 apt-get update
 apt-get -y upgrade
-apt-get -y install build-essential fuse libfuse-dev libsodium-dev libcurl4-openssl-dev libevent-dev libssl-dev zlib1g-dev
+apt-get -y install build-essential fuse libfuse-dev libsodium-dev libcurl4-openssl-dev libevent-dev libssl-dev zlib1g-dev libdw-dev
 apt-get -y install git valgrind time attr curl strace python3

--- a/misc/prereqs.ubuntu:xenial
+++ b/misc/prereqs.ubuntu:xenial
@@ -2,7 +2,7 @@
 set -x
 apt-get -y update
 apt-get -y upgrade
-apt-get -y install build-essential fuse libfuse-dev libsodium-dev libcurl4-openssl-dev libevent-dev libssl-dev
+apt-get -y install build-essential fuse libfuse-dev libsodium-dev libcurl4-openssl-dev libevent-dev libssl-dev libdw-dev
 apt-get -y install git valgrind time attr curl python3
 apt-get -y install strace
 apt-get -y install software-properties-common


### PR DESCRIPTION
make check in core123 now works with icc and clang.

travis.yml now runs the core123 regressions on all platforms.  

This required tweaks to the prereqs, and a couple of small bug-fixes and warning-evasions.

