### PR TITLE
Upload failing build artifacts to https://transfer.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
     - sudo modprobe fuse
     - sudo chmod 666 /dev/fuse
     - sudo chown root:$USER /etc/fuse.conf
+    - sudo sysctl -w kernel.core_pattern=%p.core
 
 install:
     - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin || true
@@ -42,14 +43,13 @@ script:
         ./misc/dockrun ${DOCKER_IMAGE}
         /bin/sh -e -c "cd /fs123 && . ./misc/prereqs.${DOCKER_IMAGE} && mkdir build && cd build && make -f ../GNUmakefile -j4 check && make -f ../GNUmakefile -j4 core123-check && make -f ../GNUmakefile install"
 
-# There must be a better way ...
+# Upload all the files to a pastebin-like service: https://transfer.sh
 after_failure:
-    - cat build/s/fs123.diag
-    - cat build/s/errorlog.1 s/errorlog
-    - cat build/s/exportd.*
-    - cat build/c/fs123.diag
-    - cat build/c/fs123.err
-    - cat build/c/fs123.exstatus
+    - sudo apt-get install -qq curl zstd
+    - echo 'curl -s -T "$1" https://transfer.sh; echo' >transfer.sh
+    - sudo tar -I zstd -cf server.tar.zstd build/s && sh transfer.sh server.tar.zstd
+    - sudo tar -I zstd -cf client.tar.zstd build/c && sh transfer.sh client.tar.zstd
+    - sudo tar -I zstd -cf core123-build.tar.zstd build/core123-build && sh transfer.sh core123-build.tar.zstd
 
 before_deploy:
     - >

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ prerequisites in different distros.
 The prerequisites to compile and link the client and server are:
 
 - gcc
-    10.0.1 (Fedora32), 9.2.0 (alpine 3.11.5), 8.3.1 (Fedora29), 8.2.0 (bionic), 9.2.1 (xenial), devtoolset-8-gcc-8.2.1 (CentOS7) have been tested. Any compiler with full C++17 support should work.
+    11.2.1 (Fedora34), 10.3.1 (alpine 3.14), 10.0.1 (Fedora32), 9.2.0 (alpine 3.11.5), 8.3.1 (Fedora29), 8.2.0 (bionic), 9.2.1 (xenial), devtoolset-8-gcc-8.2.1 (CentOS7) have been tested. Any compiler with full C++17 support should work.
 - gmake
     3.82 has been tested.
 - libfuse
@@ -43,9 +43,9 @@ The prerequisites to compile and link the client and server are:
 - libsodium
     1.10.18 (on Fedora32, alpine 3.11.5), 1.0.17 (on Fedora29, CentOS7), 1.0.16 (on bionic), 1.0.8 (on xenial) have been tested
 - libcurl
-    7.69 (on Fedora32), 7.67 (on alpine 3.11.5), 7.61 (on Fedora29), 7.58.0 (on bionic), 7.43.0 (on xenial), 7.19.0 (on CentOS7) have been tested
+    7.79 (alpine 3.14), 7.76 (Fedora34), 7.74 (Debian Bullseye), 7.69 (on Fedora32), 7.67 (on alpine 3.11.5), 7.61 (on Fedora29), 7.58.0 (on bionic), 7.43.0 (on xenial), 7.19.0 (on CentOS7) have been tested
 - libevent
-    2.1.11 (on alpine 3.11.5), 2.1.8 (on Fedora32, Fedora29, bionic), 2.0.21 (on xenial, CentOS7) have been tested
+    2.1.12 (alpine 3.14, Fedora34, Debian Bullseye), 2.1.11 (on alpine 3.11.5), 2.1.8 (on Fedora32, Fedora29, bionic), 2.0.21 (on xenial, CentOS7) have been tested
     
 Although only a few combinations have been tested, it's very likely that other combinations will work.
 


### PR DESCRIPTION
https://transfer.sh/ is an anonymous pastebin-like service that works
for now.